### PR TITLE
Add as option to file-download API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 0.1.2
+### Added
+- Add as argument to `file-downlaod` API
+
+### Breaking
+- (Only Clojure) Change `file-download` default response body type from String to byte array
+
 ## 0.1.1 - 2019-09-04
 ### Fixed
 - Make dynamic function name surrounded by `*`

--- a/src/kintone/connection.cljc
+++ b/src/kintone/connection.cljc
@@ -110,7 +110,8 @@
     (let [c (chan)
           req (post-as-get req)
           req #?(:clj (-> (*build-req* this req c)
-                          (dissoc :accept :as :coerce))
+                          (dissoc :accept :coerce)
+                          (assoc :as (or (:as req) :byte-array)))
                  :cljs (-> (*build-req* this req c)
                            (dissoc :format)
                            (assoc :response-format (ajax/raw-response-format))))]

--- a/src/kintone/record.cljc
+++ b/src/kintone/record.cljc
@@ -600,14 +600,24 @@
 (defn file-download
   "Download a file from an attachment field in an app.
 
-  file-key - The value is set on the attachment field in the response
+  file-key - The value(string) is set on the attachment field in the response
              that is gotten from GET record APIs.
              So the file-key is different from that
-             obtained from the response when using the Upload File API."
-  [conn file-key]
-  (let [url (pt/-url conn path/file)
-        params {:fileKey file-key}]
-    (pt/-get-blob conn url {:params params})))
+             obtained from the response when using the Upload File API.
+
+  as - (Only Clojure) A keyword that is used for output coercion.
+       default :byte-array
+       See clj-http document for detail."
+  ([conn file-key]
+   (let [url (pt/-url conn path/file)
+         params {:fileKey file-key}]
+     (pt/-get-blob conn url {:params params})))
+
+  #?(:clj
+     ([conn file-key as]
+      (let [url (pt/-url conn path/file)
+            params {:fileKey file-key}]
+        (pt/-get-blob conn url {:params params :as as})))))
 
 (defn bulk-request
   "Runs multiple API requests to multiple apps in one go.

--- a/test/kintone/connection_test.cljc
+++ b/test/kintone/connection_test.cljc
@@ -402,9 +402,23 @@
                   :async? true
                   :connection-timeout 10000
                   :socket-timeout 30000
-                  :form-params {:id 1}}
+                  :form-params {:id 1}
+                  :as :byte-array}
                  nil)
-                (<!! (pt/-get-blob conn url {:params {:id 1}}))))))
+                (<!! (pt/-get-blob conn url {:params {:id 1}}))))
+
+         (is (= (t/->KintoneResponse
+                 {:headers {"X-Cybozu-API-Token" "TestApiToken"
+                            "X-HTTP-Method-Override" "GET"}
+                  :content-type :json
+                  :async? true
+                  :connection-timeout 10000
+                  :socket-timeout 30000
+                  :form-params {:id 1}
+                  :as :stream}
+                 nil)
+                (<!! (pt/-get-blob conn url {:params {:id 1}
+                                             :as :stream}))))))
 
      (testing "Negative"
        (testing "ExceptionInfo"
@@ -549,4 +563,3 @@
                    :response {:message "Something bad happen"}})
                  (<! (pt/-multipart-post conn url {:multipart [{:id 1}]})))))
         (done)))))
-


### PR DESCRIPTION
Add `as` option to `kintone.record/file-download` API and change its default response body type from String to byte array.