### PR TITLE
Default total count true for get-records-by-query

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ These tests actually interact with a kintone app. These are good examples of kin
 ```
 - try tests
 
+## Note
+- kintone-clj doesn't convert a camelCase keyword (in kintone REST api response map) into kebab-case.
+It costs too much to do so (response map can be so complicated, and keyword can be non-ascii character).
+
 ## License
 
 Copyright 2019 TOYOKUMO,Inc.

--- a/dev/test.clj
+++ b/dev/test.clj
@@ -67,7 +67,7 @@
                 :res
                 :id)]
       (is (= nil (:err (<!! (record/get-records-by-query conn app)))))
-      (is (= "3" (-> (<!! (record/get-records-by-query conn app {:total-count true}))
+      (is (= "3" (-> (<!! (record/get-records-by-query conn app))
                      :res
                      :totalCount)))
       (is (= nil (:err (<!! (record/get-records-by-query conn app {:fields [:$id]})))))

--- a/src/kintone/record.cljc
+++ b/src/kintone/record.cljc
@@ -29,6 +29,8 @@
 
     :query - The kintone query.
              string or nil
+
+   A response map contains the totalCount of query-matched records.
   "
   ([conn app]
    (get-records-by-query conn app nil))

--- a/src/kintone/record.cljc
+++ b/src/kintone/record.cljc
@@ -30,7 +30,7 @@
     :query - The kintone query.
              string or nil
 
-   A response map contains the totalCount of query-matched records.
+   A response map always contains the totalCount of query-matched records.
   "
   ([conn app]
    (get-records-by-query conn app nil))

--- a/src/kintone/record.cljc
+++ b/src/kintone/record.cljc
@@ -29,18 +29,14 @@
 
     :query - The kintone query.
              string or nil
-
-    :total-count - If true, the request will retrieve
-                   total count of records match with query conditions.
-                   boolean or nil"
+  "
   ([conn app]
    (get-records-by-query conn app nil))
-  ([conn app {:keys [fields query total-count]}]
+  ([conn app {:keys [fields query]}]
    (let [url (pt/-url conn path/records)
-         params (cond-> {:app app}
+         params (cond-> {:app app :totalCount true}
                   (seq fields) (assoc :fields fields)
-                  (seq query) (assoc :query query)
-                  (not (nil? total-count)) (assoc :totalCount total-count))]
+                  (seq query) (assoc :query query))]
      (pt/-get conn url {:params params}))))
 
 (defn create-cursor

--- a/test/kintone/record_test.clj
+++ b/test/kintone/record_test.clj
@@ -58,17 +58,20 @@
 
 (deftest get-records-by-query-test
   (is (= (t/->KintoneResponse {:url "https://test.kintone.com/k/v1/records.json"
-                               :req {:params {:app app}}}
+                               :req {:params {:app app
+                                              :totalCount true}}}
                               nil)
          (<!! (r/get-records-by-query fake-conn app))))
 
   (is (= (t/->KintoneResponse {:url "https://test.kintone.com/k/v1/records.json"
-                               :req {:params {:app app}}}
+                               :req {:params {:app app
+                                              :totalCount true}}}
                               nil)
          (<!! (r/get-records-by-query fake-conn app {}))))
 
   (is (= (t/->KintoneResponse {:url "https://test.kintone.com/k/v1/records.json"
                                :req {:params {:app app
+                                              :totalCount true
                                               :fields [:$id :name]
                                               :query "order by $id limit 10"}}}
                               nil)

--- a/test/kintone/record_test.cljs
+++ b/test/kintone/record_test.cljs
@@ -63,17 +63,20 @@
   (async done
     (go
      (is (= (t/->KintoneResponse {:url "https://test.kintone.com/k/v1/records.json"
-                                  :req {:params {:app app}}}
+                                  :req {:params {:app app
+                                                 :totalCount true}}}
                                  nil)
             (<! (r/get-records-by-query fake-conn app))))
 
      (is (= (t/->KintoneResponse {:url "https://test.kintone.com/k/v1/records.json"
-                                  :req {:params {:app app}}}
+                                  :req {:params {:app app
+                                                 :totalCount true}}}
                                  nil)
             (<! (r/get-records-by-query fake-conn app {}))))
 
      (is (= (t/->KintoneResponse {:url "https://test.kintone.com/k/v1/records.json"
                                   :req {:params {:app app
+                                                 :totalCount true
                                                  :fields [:$id :name]
                                                  :query "order by $id limit 10"}}}
                                  nil)


### PR DESCRIPTION
# Rationale
before:
```clj
(-> (<!! (record/get-records-by-query conn app {:total-count true}))
     :res
     :totalCount)
```
It requires kebab-case keyword but returns with camelCase keyword. This is confusing.
after:
```clj
(-> (<!! (record/get-records-by-query conn app))
     :res
     :totalCount)
```
This situation only happens in `get-records-by-query` for now.  To set `totalCount: true` makes it easy.

Note for kebab-case and camelCase is also added.