### PR TITLE
Enable to override handler and error-handler to use Connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - See Content-Type of the error response ([#9](https://github.com/toyokumo/kintone-clj/pull/9))
+- Add `handler` and `error-handler` options to `new-connection` ([#10](https://github.com/toyokumo/kintone-clj/pull/10))
 
 ## 0.3.0
 ### Added

--- a/src/kintone/connection.cljc
+++ b/src/kintone/connection.cljc
@@ -25,9 +25,18 @@
             :keywords? true
             :timeout (* 1000 30)}))
 
-(defn- handler [channel res]
+(defn- default-handler [channel res]
   #?(:clj (put! channel (t/->KintoneResponse (:body res) nil))
      :cljs (put! channel (t/->KintoneResponse res nil))))
+
+(defn- wrap-handler [handler channel]
+  (fn [res]
+    (put! channel (t/->KintoneResponse (handler res) nil))))
+
+(defn- ->handler [handler channel]
+  (if handler
+    (wrap-handler handler channel)
+    (partial default-handler channel)))
 
 #?(:clj
    (defn- format-err [err]
@@ -51,9 +60,18 @@
        :else
        err)))
 
-(defn- err-handler [channel err]
+(defn- default-err-handler [channel err]
   #?(:clj (put! channel (t/->KintoneResponse nil (format-err err)))
      :cljs (put! channel (t/->KintoneResponse nil err))))
+
+(defn- wrap-error-handler [error-handler channel]
+  (fn [err]
+    (put! channel (t/->KintoneResponse nil (error-handler err)))))
+
+(defn- ->error-handler [error-handler channel]
+  (if error-handler
+    (wrap-error-handler error-handler channel)
+    (partial default-err-handler channel)))
 
 #?(:clj
    (defn- build-req
@@ -68,13 +86,13 @@
 
 #?(:cljs
    (defn- build-req
-     [{:keys [auth timeout headers]} req channel]
+     [{:keys [auth timeout headers handler error-handler]} req channel]
      (cond-> (assoc *default-req*
                     :headers (merge (pt/-header auth)
                                     headers
                                     (:headers req))
-                    :handler (partial handler channel)
-                    :error-handler (partial err-handler channel))
+                    :handler (->handler handler channel)
+                    :error-handler (->error-handler error-handler channel))
        timeout (assoc :timeout timeout)
        (:params req) (assoc :params (:params req)))))
 
@@ -83,6 +101,7 @@
 
 (defrecord Connection
   [auth domain guest-space-id
+   handler error-handler
    connection-timeout socket-timeout timeout
    headers]
   pt/IRequest
@@ -98,19 +117,19 @@
   (-post [this url req]
     (let [c (chan)
           req (build-req this req c)]
-      #?(:clj (client/post url req (partial handler c) (partial err-handler c))
+      #?(:clj (client/post url req (->handler handler c) (->error-handler error-handler c))
          :cljs (ajax/POST url req))
       c))
   (-put [this url req]
     (let [c (chan)
           req (build-req this req c)]
-      #?(:clj (client/put url req (partial handler c) (partial err-handler c))
+      #?(:clj (client/put url req (->handler handler c) (->error-handler error-handler c))
          :cljs (ajax/PUT url req))
       c))
   (-delete [this url req]
     (let [c (chan)
           req (build-req this req c)]
-      #?(:clj (client/delete url req (partial handler c) (partial err-handler c))
+      #?(:clj (client/delete url req (->handler handler c) (->error-handler error-handler c))
          :cljs (ajax/DELETE url req))
       c))
   (-get-blob [this url req]
@@ -122,7 +141,7 @@
                  :cljs (-> (build-req this req c)
                            (dissoc :format)
                            (assoc :response-format (ajax/raw-response-format))))]
-      #?(:clj (client/post url req (partial handler c) (partial err-handler c))
+      #?(:clj (client/post url req (->handler handler c) (->error-handler error-handler c))
          :cljs (ajax/POST url req))
       c))
   (-multipart-post [this url req]
@@ -133,14 +152,16 @@
                           (assoc :multipart (:multipart req)))
                  :cljs (-> (build-req this req c)
                            (dissoc :format)
-                           (assoc :body (:multipart req))))]
+                           (assoc :body (:multipart req))))
+          handler (->handler handler c)
+          error-handler (->error-handler error-handler c)]
       #?(:clj (thread
                (try
-                 (handler c (client/post url req))
+                 (handler (client/post url req))
                  (catch ExceptionInfo e
-                   (err-handler c e))
+                   (error-handler e))
                  (catch Exception e
-                   (err-handler c e))))
+                   (error-handler e))))
          :cljs (ajax/POST url req))
       c)))
 
@@ -156,6 +177,16 @@
 
   :guest-space-id - kintone guest space id
                     integer, optional
+
+  :handler - The handler function for successful operation should accept a single parameter
+             which is the response. If you do not provide this,
+             the default-handler above will be called instead.
+             function, optional
+
+  :error-handler - The handler function for error operation should accept a single parameter
+                   which is the response. If you do not provide this,
+                   the default-error-handler above will be called instead.
+                   function, optional
 
   See: https://github.com/dakrone/clj-http or https://github.com/JulianBirch/cljs-ajax
 
@@ -175,10 +206,12 @@
 
   :headers - map, optional"
   [{:keys [auth domain guest-space-id
+           handler error-handler
            connection-timeout socket-timeout timeout
            headers]}]
   (let [domain #?(:clj domain
                   :cljs (or domain (.-hostname js/location)))]
     (->Connection auth domain guest-space-id
+                  handler error-handler
                   connection-timeout socket-timeout timeout
                   headers)))

--- a/src/kintone/connection.cljc
+++ b/src/kintone/connection.cljc
@@ -181,11 +181,13 @@
   :handler - The handler function for successful operation should accept a single parameter
              which is the response. If you do not provide this,
              the default-handler above will be called instead.
+             The value it returns will put into the channel, which is the return value.
              function, optional
 
   :error-handler - The handler function for error operation should accept a single parameter
                    which is the response. If you do not provide this,
                    the default-error-handler above will be called instead.
+                   The value it returns will put into the channel, which is the return value.
                    function, optional
 
   See: https://github.com/dakrone/clj-http or https://github.com/JulianBirch/cljs-ajax

--- a/test/kintone/connection_test.cljc
+++ b/test/kintone/connection_test.cljc
@@ -15,14 +15,30 @@
 
 (deftest new-connection-test
   (is (= {:auth auth
-          :domain "sample.kintone.com",
-          :guest-space-id nil,
-          :connection-timeout nil,
-          :socket-timeout nil,
+          :domain "sample.kintone.com"
+          :guest-space-id nil
+          :handler nil
+          :error-handler nil
+          :connection-timeout nil
+          :socket-timeout nil
           :timeout nil,
           :headers nil}
          (into {} (new-connection {:auth auth
-                                   :domain "sample.kintone.com"})))))
+                                   :domain "sample.kintone.com"}))))
+
+  (is (= {:auth auth
+          :domain "sample.kintone.com"
+          :guest-space-id nil
+          :handler println
+          :error-handler prn
+          :connection-timeout nil
+          :socket-timeout nil
+          :timeout nil
+          :headers nil}
+         (into {} (new-connection {:auth auth
+                                   :domain "sample.kintone.com"
+                                   :handler println
+                                   :error-handler prn})))))
 
 (deftest -path-test
   (is (= "/k/mypath"
@@ -62,21 +78,41 @@
 #?(:clj
    (deftest -get-test
      (testing "Positive"
-       (with-redefs [client/post (fn [url req h eh]
-                                   (h {:body req}))]
-         (is (= (t/->KintoneResponse
-                 {:headers {"X-Cybozu-API-Token" "TestApiToken"
-                            "X-HTTP-Method-Override" "GET"}
-                  :accept :json
-                  :content-type :json
-                  :as :json
-                  :async? true
-                  :coerce :unexceptional
-                  :connection-timeout 10000
-                  :socket-timeout 30000
-                  :form-params {:id 1}}
-                 nil)
-                (<!! (pt/-get conn url {:params {:id 1}}))))))
+       (testing "default-handler"
+         (with-redefs [client/post (fn [url req h eh]
+                                     (h {:body req}))]
+           (is (= (t/->KintoneResponse
+                   {:headers {"X-Cybozu-API-Token" "TestApiToken"
+                              "X-HTTP-Method-Override" "GET"}
+                    :accept :json
+                    :content-type :json
+                    :as :json
+                    :async? true
+                    :coerce :unexceptional
+                    :connection-timeout 10000
+                    :socket-timeout 30000
+                    :form-params {:id 1}}
+                   nil)
+                  (<!! (pt/-get conn url {:params {:id 1}}))))))
+
+       (testing "custom handler"
+         (with-redefs [client/post (fn [url req h eh]
+                                     (h {:body req}))]
+           (is (= (t/->KintoneResponse
+                   {:body {:headers {"X-Cybozu-API-Token" "TestApiToken"
+                                     "X-HTTP-Method-Override" "GET"}
+                           :accept :json
+                           :content-type :json
+                           :as :json
+                           :async? true
+                           :coerce :unexceptional
+                           :connection-timeout 10000
+                           :socket-timeout 30000
+                           :form-params {:id 1}}}
+                   nil)
+                  (<!! (pt/-get (assoc conn :handler identity)
+                                url
+                                {:params {:id 1}})))))))
 
      (testing "Negative"
        (testing "ExceptionInfo"
@@ -106,7 +142,21 @@
                      {:status 400
                       :status-text "400"
                       :response "<!DOCTYPE html><html></html>"})
-                    (<!! (pt/-get conn url {:params {:id 1}})))))))
+                    (<!! (pt/-get conn url {:params {:id 1}}))))))
+
+         (testing "custom error-handler"
+           (with-redefs [client/post
+                         (fn [url req h eh]
+                           (eh (ex-info "Test error"
+                                        {:status 400
+                                         :headers {"Content-Type" "application/json; charset=utf-8"}
+                                         :body "{\"message\":\"Something bad happen\"}"})))]
+             (is (= (t/->KintoneResponse
+                     nil
+                     "{\"message\":\"Something bad happen\"}")
+                    (<!! (pt/-get (assoc conn :error-handler (fn [err] (:body (ex-data err))))
+                                  url
+                                  {:params {:id 1}})))))))
 
        (testing "Exception"
          (with-redefs [client/post
@@ -142,6 +192,25 @@
         (done)))))
 
 #?(:cljs
+   (deftest -get-test-positive-with-custom-handler
+     (async done
+       (go
+        (with-redefs [ajax.easy/easy-ajax-request
+                      (fn [uri method opts]
+                        (is (= method "POST"))
+                        ((:handler opts)
+                         (dissoc opts
+                                 :handler
+                                 :error-handler)))]
+          (is (= (t/->KintoneResponse
+                  {:id 1}
+                  nil)
+                 (<! (pt/-get (assoc conn :handler :params)
+                              url
+                              {:params {:id 1}})))))
+        (done)))))
+
+#?(:cljs
    (deftest -get-test-negative
      (async done
        (go
@@ -158,6 +227,25 @@
                    :status-text "400"
                    :response {:message "Something bad happen"}})
                  (<! (pt/-get conn url {:params {:id 1}})))))
+        (done)))))
+
+#?(:cljs
+   (deftest -get-test-negative-with-custom-error-handler
+     (async done
+       (go
+        (with-redefs [ajax.easy/easy-ajax-request
+                      (fn [uri method opts]
+                        (is (= method "POST"))
+                        ((:error-handler opts)
+                         {:status 400
+                          :status-text "400"
+                          :response {:message "Something bad happen"}}))]
+          (is (= (t/->KintoneResponse
+                  nil
+                  {:message "Something bad happen"})
+                 (<! (pt/-get (assoc conn :error-handler :response)
+                              url
+                              {:params {:id 1}})))))
         (done)))))
 
 #?(:clj
@@ -177,6 +265,16 @@
                   :form-params {:id 1}}
                  nil)
                 (<!! (pt/-post conn url {:params {:id 1}}))))))
+
+     (testing "Positive but custom handler"
+       (with-redefs [client/post (fn [url req h eh]
+                                   (h {:body req}))]
+         (is (= (t/->KintoneResponse
+                 {:id 1}
+                 nil)
+                (<!! (pt/-post (assoc conn :handler (comp :form-params :body))
+                               url
+                               {:params {:id 1}}))))))
 
      (testing "Negative"
        (testing "ExceptionInfo"
@@ -206,7 +304,21 @@
                      {:status 400
                       :status-text "400"
                       :response "<!DOCTYPE html><html></html>"})
-                    (<!! (pt/-post conn url {:params {:id 1}})))))))
+                    (<!! (pt/-post conn url {:params {:id 1}}))))))
+
+         (testing "custom error-handler"
+           (with-redefs [client/post
+                         (fn [url req h eh]
+                           (eh (ex-info "Test error"
+                                        {:status 400
+                                         :headers {"Content-Type" "text/html; charset=utf-8"}
+                                         :body "<!DOCTYPE html><html></html>"})))]
+             (is (= (t/->KintoneResponse
+                     nil
+                     "<!DOCTYPE html><html></html>")
+                    (<!! (pt/-post (assoc conn :error-handler (fn [err] (:body (ex-data err))))
+                                   url
+                                   {:params {:id 1}})))))))
 
        (testing "Exception"
          (with-redefs [client/post
@@ -241,6 +353,25 @@
         (done)))))
 
 #?(:cljs
+   (deftest -post-test-positive-with-custom-handler
+     (async done
+       (go
+        (with-redefs [ajax.easy/easy-ajax-request
+                      (fn [uri method opts]
+                        (is (= method "POST"))
+                        ((:handler opts)
+                         (dissoc opts
+                                 :handler
+                                 :error-handler)))]
+          (is (= (t/->KintoneResponse
+                  {:id 1}
+                  nil)
+                 (<! (pt/-post (assoc conn :handler :params)
+                               url
+                               {:params {:id 1}})))))
+        (done)))))
+
+#?(:cljs
    (deftest -post-test-negative
      (async done
        (go
@@ -256,6 +387,24 @@
                    :status-text "400"
                    :response {:message "Something bad happen"}})
                  (<! (pt/-post conn url {:params {:id 1}})))))
+        (done)))))
+
+#?(:cljs
+   (deftest -post-test-negative-with-custom-handler
+     (async done
+       (go
+        (with-redefs [ajax.easy/easy-ajax-request
+                      (fn [uri method opts]
+                        ((:error-handler opts)
+                         {:status 400
+                          :status-text "400"
+                          :response {:message "Something bad happen"}}))]
+          (is (= (t/->KintoneResponse
+                  nil
+                  400)
+                 (<! (pt/-post (assoc conn :error-handler :status)
+                               url
+                               {:params {:id 1}})))))
         (done)))))
 
 #?(:clj
@@ -275,6 +424,16 @@
                   :form-params {:id 1}}
                  nil)
                 (<!! (pt/-put conn url {:params {:id 1}}))))))
+
+     (testing "Positive but custom handler"
+       (with-redefs [client/put (fn [url req h eh]
+                                  (h {:body req}))]
+         (is (= (t/->KintoneResponse
+                 {:id 1}
+                 nil)
+                (<!! (pt/-put (assoc conn :handler (comp :form-params :body))
+                              url
+                              {:params {:id 1}}))))))
 
      (testing "Negative"
        (testing "ExceptionInfo"
@@ -304,7 +463,21 @@
                      {:status 400
                       :status-text "400"
                       :response "<!DOCTYPE html><html></html>"})
-                    (<!! (pt/-put conn url {:params {:id 1}})))))))
+                    (<!! (pt/-put conn url {:params {:id 1}}))))))
+
+         (testing "custom error-handler"
+           (with-redefs [client/put
+                         (fn [url req h eh]
+                           (eh (ex-info "Test error"
+                                        {:status 400
+                                         :headers {"Content-Type" "application/json; charset=utf-8"}
+                                         :body "{\"message\":\"Something bad happen\"}"})))]
+             (is (= (t/->KintoneResponse
+                     nil
+                     "{\"message\":\"Something bad happen\"}")
+                    (<!! (pt/-put (assoc conn :error-handler (comp :body ex-data))
+                                  url
+                                  {:params {:id 1}})))))))
 
        (testing "Exception"
          (with-redefs [client/put
@@ -339,6 +512,30 @@
         (done)))))
 
 #?(:cljs
+   (deftest -put-test-positive-with-custom-handler
+     (async done
+       (go
+        (with-redefs [ajax.easy/easy-ajax-request
+                      (fn [uri method opts]
+                        (is (= method "PUT"))
+                        ((:handler opts)
+                         (dissoc opts
+                                 :handler
+                                 :error-handler)))]
+          (is (= (t/->KintoneResponse
+                  {:headers {"X-Cybozu-API-Token" "TestApiToken"}
+                   :format :json
+                   :response-format :json
+                   :keywords? true
+                   :timeout 30000
+                   :params {:id 2}}
+                  nil)
+                 (<! (pt/-put (assoc conn :handler #(update-in % [:params :id] inc))
+                              url
+                              {:params {:id 1}})))))
+        (done)))))
+
+#?(:cljs
    (deftest -put-test-negative
      (async done
        (go
@@ -354,6 +551,24 @@
                    :status-text "400"
                    :response {:message "Something bad happen"}})
                  (<! (pt/-put conn url {:params {:id 1}})))))
+        (done)))))
+
+#?(:cljs
+   (deftest -put-test-negative-with-custom-error-handler
+     (async done
+       (go
+        (with-redefs [ajax.easy/easy-ajax-request
+                      (fn [uri method opts]
+                        ((:error-handler opts)
+                         {:status 400
+                          :status-text "400"
+                          :response {:message "Something bad happen"}}))]
+          (is (= (t/->KintoneResponse
+                  nil
+                  "Something bad happen")
+                 (<! (pt/-put (assoc conn :error-handler #(get-in % [:response :message]))
+                              url
+                              {:params {:id 1}})))))
         (done)))))
 
 #?(:clj
@@ -373,6 +588,16 @@
                   :form-params {:id 1}}
                  nil)
                 (<!! (pt/-delete conn url {:params {:id 1}}))))))
+
+     (testing "Positive but custom handler"
+       (with-redefs [client/delete (fn [url req h eh]
+                                     (h {:body req}))]
+         (is (= (t/->KintoneResponse
+                 {:id 1}
+                 nil)
+                (<!! (pt/-delete (assoc conn :handler (comp :form-params :body))
+                                 url
+                                 {:params {:id 1}}))))))
 
      (testing "Negative"
        (testing "ExceptionInfo"
@@ -402,7 +627,21 @@
                      {:status 400
                       :status-text "400"
                       :response "<!DOCTYPE html><html></html>"})
-                    (<!! (pt/-delete conn url {:params {:id 1}})))))))
+                    (<!! (pt/-delete conn url {:params {:id 1}}))))))
+
+         (testing "custom error-handler"
+           (with-redefs [client/delete
+                         (fn [url req h eh]
+                           (eh (ex-info "Test error"
+                                        {:status 400
+                                         :headers {"Content-Type" "application/json; charset=utf-8"}
+                                         :body "{\"message\":\"Something bad happen\"}"})))]
+             (is (= (t/->KintoneResponse
+                     nil
+                     "{\"message\":\"Something bad happen\"}")
+                    (<!! (pt/-delete (assoc conn :error-handler (comp :body ex-data))
+                                     url
+                                     {:params {:id 1}})))))))
 
        (testing "Exception"
          (with-redefs [client/delete
@@ -437,6 +676,25 @@
         (done)))))
 
 #?(:cljs
+   (deftest -delete-test-positive-with-custom-handler
+     (async done
+       (go
+        (with-redefs [ajax.easy/easy-ajax-request
+                      (fn [uri method opts]
+                        (is (= method "DELETE"))
+                        ((:handler opts)
+                         (dissoc opts
+                                 :handler
+                                 :error-handler)))]
+          (is (= (t/->KintoneResponse
+                  {:id 1}
+                  nil)
+                 (<! (pt/-delete (assoc conn :handler :params)
+                                 url
+                                 {:params {:id 1}})))))
+        (done)))))
+
+#?(:cljs
    (deftest -delete-test-negative
      (async done
        (go
@@ -452,6 +710,24 @@
                    :status-text "400"
                    :response {:message "Something bad happen"}})
                  (<! (pt/-delete conn url {:params {:id 1}})))))
+        (done)))))
+
+#?(:cljs
+   (deftest -delete-test-negative-with-custom-error-handler
+     (async done
+       (go
+        (with-redefs [ajax.easy/easy-ajax-request
+                      (fn [uri method opts]
+                        ((:error-handler opts)
+                         {:status 400
+                          :status-text "400"
+                          :response {:message "Something bad happen"}}))]
+          (is (= (t/->KintoneResponse
+                  nil
+                  {:message "Something bad happen"})
+                 (<! (pt/-delete (assoc conn :error-handler :response)
+                                 url
+                                 {:params {:id 1}})))))
         (done)))))
 
 #?(:clj
@@ -484,6 +760,16 @@
                 (<!! (pt/-get-blob conn url {:params {:id 1}
                                              :as :stream}))))))
 
+     (testing "Positive but custom handler"
+       (with-redefs [client/post (fn [url req h eh]
+                                   (h {:body req}))]
+         (is (= (t/->KintoneResponse
+                 {:id 1}
+                 nil)
+                (<!! (pt/-get-blob (assoc conn :handler (comp :form-params :body))
+                                   url
+                                   {:params {:id 1}}))))))
+
      (testing "Negative"
        (testing "ExceptionInfo"
          (testing "JSON response"
@@ -512,7 +798,21 @@
                      {:status 400
                       :status-text "400"
                       :response "<!DOCTYPE html><html></html>"})
-                    (<!! (pt/-get-blob conn url {:params {:id 1}})))))))
+                    (<!! (pt/-get-blob conn url {:params {:id 1}}))))))
+
+         (testing "custom error-handler"
+           (with-redefs [client/post
+                         (fn [url req h eh]
+                           (eh (ex-info "Test error"
+                                        {:status 400
+                                         :headers {"Content-Type" "application/json; charset=utf-8"}
+                                         :body "{\"message\":\"Something bad happen\"}"})))]
+             (is (= (t/->KintoneResponse
+                     nil
+                     "{\"message\":\"Something bad happen\"}")
+                    (<!! (pt/-get-blob (assoc conn :error-handler (comp :body ex-data))
+                                       url
+                                       {:params {:id 1}})))))))
 
        (testing "Exception"
          (with-redefs [client/post
@@ -547,6 +847,25 @@
         (done)))))
 
 #?(:cljs
+   (deftest -get-blob-test-positive-with-custom-handler
+     (async done
+       (go
+        (with-redefs [ajax.easy/easy-ajax-request
+                      (fn [uri method opts]
+                        (is (= method "POST"))
+                        ((:handler opts)
+                         (dissoc opts
+                                 :handler
+                                 :error-handler)))]
+          (let [{:keys [res err]} (<! (pt/-get-blob (assoc conn :handler :params)
+                                                    url
+                                                    {:params {:id 1}}))]
+            (is (= {:id 1}
+                   res))
+            (is (= err nil))))
+        (done)))))
+
+#?(:cljs
    (deftest -get-blob-test-negative
      (async done
        (go
@@ -564,6 +883,24 @@
                  (<! (pt/-get-blob conn url {:params {:id 1}})))))
         (done)))))
 
+#?(:cljs
+   (deftest -get-blob-test-negative-with-custom-error-handler
+     (async done
+       (go
+        (with-redefs [ajax.easy/easy-ajax-request
+                      (fn [uri method opts]
+                        ((:error-handler opts)
+                         {:status 400
+                          :status-text "400"
+                          :response {:message "Something bad happen"}}))]
+          (is (= (t/->KintoneResponse
+                  nil
+                  {:message "Something bad happen"})
+                 (<! (pt/-get-blob (assoc conn :error-handler :response)
+                                   url
+                                   {:params {:id 1}})))))
+        (done)))))
+
 #?(:clj
    (deftest -multipart-test
      (testing "Positive"
@@ -579,6 +916,16 @@
                   :multipart [{:id 1}]}
                  nil)
                 (<!! (pt/-multipart-post conn url {:multipart [{:id 1}]}))))))
+
+     (testing "Positive but custom handler"
+       (with-redefs [client/post (fn [url req]
+                                   {:body req})]
+         (is (= (t/->KintoneResponse
+                 [{:id 1}]
+                 nil)
+                (<!! (pt/-multipart-post (assoc conn :handler (comp :multipart :body))
+                                         url
+                                         {:multipart [{:id 1}]}))))))
 
      (testing "Negative"
        (testing "ExceptionInfo"
@@ -610,7 +957,22 @@
                      {:status 400
                       :status-text "400"
                       :response "<!DOCTYPE html><html></html>"})
-                    (<!! (pt/-multipart-post conn url {:multipart [{:id 1}]})))))))
+                    (<!! (pt/-multipart-post conn url {:multipart [{:id 1}]}))))))
+
+         (testing "custom error-handler"
+           (with-redefs [client/post
+                         (fn [url req]
+                           (throw
+                            (ex-info "Test error"
+                                     {:status 400
+                                      :headers {"Content-Type" "application/json; charset=utf-8"}
+                                      :body "{\"message\":\"Something bad happen\"}"})))]
+             (is (= (t/->KintoneResponse
+                     nil
+                     "{\"message\":\"Something bad happen\"}")
+                    (<!! (pt/-multipart-post (assoc conn :error-handler (comp :body ex-data))
+                                             url
+                                             {:multipart [{:id 1}]})))))))
 
        (testing "Exception"
          (with-redefs [client/post
@@ -644,6 +1006,25 @@
         (done)))))
 
 #?(:cljs
+   (deftest -multipart-post-test-positive-with-handler
+     (async done
+       (go
+        (with-redefs [ajax.easy/easy-ajax-request
+                      (fn [uri method opts]
+                        (is (= method "POST"))
+                        ((:handler opts)
+                         (dissoc opts
+                                 :handler
+                                 :error-handler)))]
+          (let [{:keys [res err]} (<! (pt/-multipart-post (assoc conn :handler :body)
+                                                          url
+                                                          {:multipart [{:id 1}]}))]
+            (is (= [{:id 1}]
+                   res))
+            (is (= err nil))))
+        (done)))))
+
+#?(:cljs
    (deftest -multipart-post-test-negative
      (async done
        (go
@@ -659,4 +1040,22 @@
                    :status-text "400"
                    :response {:message "Something bad happen"}})
                  (<! (pt/-multipart-post conn url {:multipart [{:id 1}]})))))
+        (done)))))
+
+#?(:cljs
+   (deftest -multipart-post-test-negative-with-custom-error-handler
+     (async done
+       (go
+        (with-redefs [ajax.easy/easy-ajax-request
+                      (fn [uri method opts]
+                        ((:error-handler opts)
+                         {:status 400
+                          :status-text "400"
+                          :response {:message "Something bad happen"}}))]
+          (is (= (t/->KintoneResponse
+                  nil
+                  {:message "Something bad happen"})
+                 (<! (pt/-multipart-post (assoc conn :error-handler :response)
+                                         url
+                                         {:multipart [{:id 1}]})))))
         (done)))))


### PR DESCRIPTION
Add `handler` and `error-handler` options to `new-connection` in order that client can handle response or error response with their own function.