### PR TITLE
Fix cljs request to notify as XMLHttpRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## Unreleased
+### Fixed
+- Add CSRF Token and `X-Requested-With` header to each request of connection of ClojureScript ([#12](https://github.com/toyokumo/kintone-clj/pull/12))
 
 ## 0.4.0
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
+.PHONY: test
+
+clean:
+	lein clean
+
 test-clj:
-	@lein test
+	lein test
 
 test-cljs:
-	@lein test:cljs
+	lein test:cljs
 
-test: test-clj test-cljs
+test:
+	lein do clean, test, test:cljs

--- a/dev.cljs.edn
+++ b/dev.cljs.edn
@@ -1,8 +1,11 @@
 ^{:watch-dirs ["src" "dev" "test"]
-  :mode :repl}
+  :mode :serve}
 {:main cljs.user
  :optimizations :none
  :warnings true
  :output-wrapper true
  :source-map true
- :closure-defines {cljs.user/DEBUG true}}
+ :closure-defines {cljs.user/DEBUG true}
+ :asset-path "https://localhost/js/out"
+ :output-dir "target/public/js/out"
+ :output-to "target/public/js/main.js"}

--- a/test/kintone/connection_test.cljc
+++ b/test/kintone/connection_test.cljc
@@ -181,7 +181,8 @@
                                  :error-handler)))]
           (is (= (t/->KintoneResponse
                   {:headers {"X-Cybozu-API-Token" "TestApiToken"
-                             "X-HTTP-Method-Override" "GET"}
+                             "X-HTTP-Method-Override" "GET"
+                             "X-Requested-With" "XMLHttpRequest"}
                    :format :json
                    :response-format :json
                    :keywords? true
@@ -342,7 +343,8 @@
                                  :handler
                                  :error-handler)))]
           (is (= (t/->KintoneResponse
-                  {:headers {"X-Cybozu-API-Token" "TestApiToken"}
+                  {:headers {"X-Cybozu-API-Token" "TestApiToken"
+                             "X-Requested-With" "XMLHttpRequest"}
                    :format :json
                    :response-format :json
                    :keywords? true
@@ -501,7 +503,8 @@
                                  :handler
                                  :error-handler)))]
           (is (= (t/->KintoneResponse
-                  {:headers {"X-Cybozu-API-Token" "TestApiToken"}
+                  {:headers {"X-Cybozu-API-Token" "TestApiToken"
+                             "X-Requested-With" "XMLHttpRequest"}
                    :format :json
                    :response-format :json
                    :keywords? true
@@ -523,7 +526,8 @@
                                  :handler
                                  :error-handler)))]
           (is (= (t/->KintoneResponse
-                  {:headers {"X-Cybozu-API-Token" "TestApiToken"}
+                  {:headers {"X-Cybozu-API-Token" "TestApiToken"
+                             "X-Requested-With" "XMLHttpRequest"}
                    :format :json
                    :response-format :json
                    :keywords? true
@@ -665,7 +669,8 @@
                                  :handler
                                  :error-handler)))]
           (is (= (t/->KintoneResponse
-                  {:headers {"X-Cybozu-API-Token" "TestApiToken"}
+                  {:headers {"X-Cybozu-API-Token" "TestApiToken"
+                             "X-Requested-With" "XMLHttpRequest"}
                    :format :json
                    :response-format :json
                    :keywords? true
@@ -837,7 +842,8 @@
                                  :error-handler)))]
           (let [{:keys [res err]} (<! (pt/-get-blob conn url {:params {:id 1}}))]
             (is (= {:headers {"X-Cybozu-API-Token" "TestApiToken"
-                              "X-HTTP-Method-Override" "GET"}
+                              "X-HTTP-Method-Override" "GET"
+                              "X-Requested-With" "XMLHttpRequest"}
                     :keywords? true
                     :timeout 30000
                     :params {:id 1}}
@@ -996,7 +1002,8 @@
                                  :handler
                                  :error-handler)))]
           (let [{:keys [res err]} (<! (pt/-multipart-post conn url {:multipart [{:id 1}]}))]
-            (is (= {:headers {"X-Cybozu-API-Token" "TestApiToken"}
+            (is (= {:headers {"X-Cybozu-API-Token" "TestApiToken"
+                              "X-Requested-With" "XMLHttpRequest"}
                     :response-format :json
                     :keywords? true
                     :timeout 30000


### PR DESCRIPTION
kintone REST API used from JavaScript requires CSRF Token and `X-Requested-With` HTTP header.
https://developer.kintone.io/hc/en-us/articles/212494388
https://developer.cybozu.io/hc/ja/articles/201732180-CSRF%E3%83%88%E3%83%BC%E3%82%AF%E3%83%B3%E5%88%A9%E7%94%A8%E6%99%82%E3%81%AE%E6%B3%A8%E6%84%8F%E7%82%B9

This PR adds them to ClojureScript sides.