### PR TITLE
Modify re-base-url to public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.6.1
+### Changed
+- Bump outdated dependencies. ([#20](https://github.com/toyokumo/kintone-client/pull/20))
+
 ## 0.6.0
 ### Added
 - Add support App API ([#15](https://github.com/toyokumo/kintone-client/pull/15))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.6.2
+### Changed
+- Make `re-base-url` to public. ([#21](https://github.com/toyokumo/kintone-client/pull/21))
+
 ## 0.6.1
 ### Changed
 - Bump outdated dependencies. ([#20](https://github.com/toyokumo/kintone-client/pull/20))

--- a/src/kintone_client/url.cljc
+++ b/src/kintone_client/url.cljc
@@ -38,7 +38,7 @@
             (str/join "|"))
        ")"))
 
-(def ^:private re-base-url
+(def re-base-url
   (re-pattern re-base-url*))
 
 (defn extract-base-url


### PR DESCRIPTION
**I made `re-base-url` to public.**

`re-base-url` is useful for [r0man/ring-cors](https://github.com/r0man/ring-cors) (a middleware for ring handler) to specify `access-control-allow-origin` for  Kintone domains.
*ring-cors can specify origins with regular expressions.

For that reason, I want to make `re-base-url` to public.

Thank you.