### PR TITLE
Add User API Token Authentication Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## Unreleased
+### Added
+- Add support for User API token authentication with Bearer authorization header
 
 ## 0.6.2
 ### Changed

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ on kintone as customize script for kintone app or portal.
 
 ;; User API token (for cybozu.com User API)
 (auth/new-auth {:user-api-token "xyz..."})
+
+;; NOTE: Basic authentication and User API token cannot be used together
+;; as they both set the Authorization header. Use one or the other.
 ```
 
 ### Make `Connection` object

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ on kintone as customize script for kintone app or portal.
 (auth/new-auth {:basic {:username "basic-username" :password "basic-password"}
                 :password {:username "login-name" :password "login-password"}
                 :api-token "xyz..."})
+
+;; User API token (for cybozu.com User API)
+(auth/new-auth {:user-api-token "xyz..."})
 ```
 
 ### Make `Connection` object

--- a/src/kintone_client/authentication.cljc
+++ b/src/kintone_client/authentication.cljc
@@ -36,7 +36,10 @@
                string
 
   :user-api-token - cybozu.com User API token.
-                    string"
+                    string
+
+  NOTE: :basic and :user-api-token cannot be used together as they both
+        set the Authorization header. Use one or the other."
   #?(:cljs
      ([]
       (->Auth nil nil nil nil)))
@@ -51,4 +54,6 @@
                      api-token)
          user-api-token (when (seq user-api-token)
                           user-api-token)]
+     (assert (not (and basic user-api-token))
+             "Basic authentication and User API token cannot be used together")
      (->Auth basic password api-token user-api-token))))

--- a/src/kintone_client/authentication.cljc
+++ b/src/kintone_client/authentication.cljc
@@ -14,13 +14,14 @@
   #?(:clj (.encodeToString (Base64/getEncoder) (.getBytes s))
      :cljs (goog.base64/encodeString s)))
 
-(defrecord Auth [basic password api-token]
+(defrecord Auth [basic password api-token user-api-token]
   pt/IAuth
   (-header [_]
     (cond-> {}
       basic (assoc "Authorization" (str "Basic " basic))
       password (assoc "X-Cybozu-Authorization" password)
-      api-token (assoc "X-Cybozu-API-Token" api-token))))
+      api-token (assoc "X-Cybozu-API-Token" api-token)
+      user-api-token (assoc "Authorization" (str "Bearer " user-api-token)))))
 
 (defn new-auth
   "Make a new Auth object.
@@ -32,11 +33,14 @@
               {:username \"...\" :password \"...\"}
 
   :api-token - kintone app api token.
-               string"
+               string
+
+  :user-api-token - cybozu.com User API token.
+                    string"
   #?(:cljs
      ([]
-      (->Auth nil nil nil)))
-  ([{:keys [basic password api-token]}]
+      (->Auth nil nil nil nil)))
+  ([{:keys [basic password api-token user-api-token]}]
    (let [basic (when (and (seq (:username basic))
                           (seq (:password basic)))
                  (base64-encode (str (:username basic) ":" (:password basic))))
@@ -44,5 +48,7 @@
                              (seq (:password password)))
                     (base64-encode (str (:username password) ":" (:password password))))
          api-token (when (seq api-token)
-                     api-token)]
-     (->Auth basic password api-token))))
+                     api-token)
+         user-api-token (when (seq user-api-token)
+                          user-api-token)]
+     (->Auth basic password api-token user-api-token))))

--- a/test/kintone_client/authentication_test.cljc
+++ b/test/kintone_client/authentication_test.cljc
@@ -28,4 +28,11 @@
                                         :password "barbar"}
                                 :password {:username "foofoo"
                                            :password "barbar"}
-                                :api-token "XXXYYYXXX"})))))
+                                :api-token "XXXYYYXXX"}))))
+
+  (is (= {"Authorization" "Bearer XXXYYYXXX"}
+         (pt/-header (new-auth {:user-api-token "XXXYYYXXX"}))))
+
+  (is (thrown? #?(:clj AssertionError :cljs js/Error)
+        (new-auth {:basic {:username "foofoo" :password "barbar"}
+                   :user-api-token "XXXYYYXXX"}))))


### PR DESCRIPTION
# Add User API Token Authentication Support
This branch adds support for cybozu.com User API token authentication. 
The User API token uses Bearer authentication in the Authorization header, which is different from the existing kintone app API token that uses the `X-Cybozu-API-Token` header.

## Key Changes

  Authentication Module (authentication.cljc):
  - Added user-api-token field to the Auth record
  - Updated the -header method to set Authorization: Bearer <token> when user-api-token is provided
  - Enhanced new-auth function to accept :user-api-token parameter
  - Added validation to prevent simultaneous use of basic authentication and user API token (both use Authorization header)

  Documentation Updates:
  - Updated README.md with usage examples for User API token authentication
  - Added note about mutual exclusivity between basic auth and user API token
  - Added changelog entry for the new feature

  Testing:
  - Added test cases for User API token header generation
  - Added test case to verify assertion error when basic auth and user API token are used together

## Usage

```clj
  ;; User API token authentication
  (auth/new-auth {:user-api-token "your-user-api-token"})

  ;; This will throw an AssertionError (not allowed)
  (auth/new-auth {:basic {:username "user" :password "pass"}
                  :user-api-token "token"})
```

  This enhancement enables developers to authenticate with cybozu.com User APIs using the appropriate Bearer token authentication method while maintaining backward compatibility with existing authentication mechanisms.